### PR TITLE
Add other dimensions e.g. time to CellCube

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.8"
           - "1.9"
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ LibExpat = "0.6"
 Makie = "0.19"
 NearestNeighbors = "0.4"
 YAXArrays = "0.4"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/cubes.jl
+++ b/src/cubes.jl
@@ -127,6 +127,7 @@ end
 function plot_map(geo_cube::GeoCube)
     # Can not use Makie plot recipies, because we need to specify the axis for GeoMakie
     # see https://discourse.julialang.org/t/accessing-axis-in-makie-plot-recipes/66006
+    geo_cube.data |> size |> length == 2 || throw(ArgumentError("GeoCube must have only spatial index dimensions"))
 
     fig = Figure()
     ax = GeoAxis(fig[1, 1]; dest="+proj=wintri", coastlines=true)

--- a/src/gridsystems.jl
+++ b/src/gridsystems.jl
@@ -1,3 +1,5 @@
+import YAXArrays: Cubes.formatbytes, Cubes.cubesize
+
 struct Level{G<:AbstractGrid}
     data::CellCube
     grid::G

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,8 +74,8 @@ using Test
         @test size(cell_cube3.data) == (329, 24)
 
         # test conversion back to geoCube again
-        geo_cube3 = GeoCube(cell_cube3)
-        @test size(geo_cube3.data) == size(geo_cube3.data)
+        geo_cube4 = GeoCube(cell_cube3)
+        @test size(geo_cube4.data) == (361, 181, 24)
     end
 
     @testset "GridSystems" begin


### PR DESCRIPTION
We want to support e.g. multiple timepoints in one cube.
GeoCube is already supported: GeoCube(array::YAXArray, latitude_name, longitude_name)
But we need to modify method converting GEoCube to CellCube e.g. using mapCube to reduce lon and lat to cell id but to keep other non-spatial index dimensions e.g. time

## TODO

- [x] Load data into GeoCube with non-spatial index dimensions e.g. time
- [x] Update function to Transform GeoCube to CellCube with non-spatial index dimensions w.g. using mapCube
- [x] Update function to Re-Transform CellCube to GeoCube allowing to keep non-spatial index dimensions
- [x] Update plot function e.g. to plot a selected time point