### PR TITLE
Danlooo/use datasets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,6 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
       - name: Run the tests
         id: referencetests
-        continue-on-error: true
         run: >
           DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --color=yes --project=. -e 'using Pkg; Pkg.test("DGGS", coverage=true)'
           && echo "TESTS_SUCCESSFUL=true" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ Create a DGGS based on a synthetic data in a geographical grid:
 lon_range = -180:180
 lat_range = -90:90
 level = 6
-data = [exp(cosd(lon)) + 3(lat / 90) for lat in lat_range, lon in lon_range]
-dggs = GridSystem(data, lon_range, lat_range, level)
+data = [exp(cosd(lon)) + 3(lat / 90) for lon in lon_range, lat in lat_range]
+dggs = to_cell_cube(data, lon_range, lat_range, level) |> GridSystem
 ```
 ```
 [ Info: Step 1/2: Transform coordinates
 [ Info: Step 2/2: Re-grid the data
 DGGS GridSystem
 Levels: 2,3,4,5,6
-Dim{:q2di_i} Sampled{Int64} 0:1:15 ForwardOrdered Regular Points,
-Dim{:q2di_j} Sampled{Int64} 0:1:15 ForwardOrdered Regular Points,
-Dim{:q2di_n} Sampled{Int64} 0:11 ForwardOrdered Regular Points
+↓ q2di_i Sampled{Int64} 0:1:15 ForwardOrdered Regular Points,
+→ q2di_j Sampled{Int64} 0:1:15 ForwardOrdered Regular Points,
+↗ q2di_n Sampled{Int64} 0:11 ForwardOrdered Regular Points
 ```
 
 Write DGGS data to disk and load them back:

--- a/src/cubes.jl
+++ b/src/cubes.jl
@@ -93,7 +93,7 @@ function map_cell_to_geo_cube(xout, xin, cell_ids_mat)
 end
 
 function to_geo_cube(cell_cube::CellCube; longitudes=-180:180, latitudes=-90:90)
-    cell_ids_mat = transform_points(longitudes, latitudes, cell_cube.level)
+    cell_ids_mat = transform_points(longitudes, latitudes, cell_cube.level).data
 
     geo_array = mapCube(
         map_cell_to_geo_cube,
@@ -149,12 +149,9 @@ function get_non_spatial_cube_axes(cell_cube)
 end
 
 function plot_geo(cell_cube::CellCube; resolution::Real=800)
-    longitudes = range(-180, 180, length=resolution) |> X
-    latitudes = range(-90, 90, length=resolution) |> Y
-
-    cell_ids_mat = transform_points(longitudes, latitudes, cell_cube.level)
-    cell_ids = DimArray(cell_ids_mat, (longitudes, latitudes))
-
+    longitudes = range(-180, 180, length=resolution)
+    latitudes = range(-90, 90, length=resolution)
+    cell_ids = transform_points(longitudes, latitudes, cell_cube.level)
     plot_geo(cell_cube, cell_ids)
 end
 
@@ -256,8 +253,7 @@ function plot_geo(cell_cube::CellCube, bbox::HyperRectangle{2,Float32}; resoluti
     max_y = min_y + bbox.widths[2]
     longitudes = range(min_x, max_x; length=resolution)
     latitudes = range(min_y, max_y; length=resolution)
-    cell_ids_mat = transform_points(longitudes, latitudes, cell_cube.level)
-    cell_ids = DimArray(cell_ids_mat, (longitudes |> X, latitudes |> Y))
+    cell_ids = transform_points(longitudes, latitudes, cell_cube.level)
     geo_cube = to_geo_cube(cell_cube, cell_ids)
 
 

--- a/src/cubes.jl
+++ b/src/cubes.jl
@@ -79,6 +79,11 @@ function to_cell_cube(raster::AbstractDimArray, level::Integer, agg_func::Functi
     CellCube(cell_cube, level)
 end
 
+function to_cell_cube(raster::AbstractMatrix, lon_range::AbstractVector, lat_range::AbstractVector, level::Integer, agg_func::Function=filter_null(mean))
+    raster = DimArray(raster, (X(lon_range), Y(lat_range)))
+    return to_cell_cube(raster, level, agg_func)
+end
+
 Base.getindex(cell_cube::CellCube; i...) = Base.getindex(cell_cube.data; i...) |> x -> CellCube(x, cell_cube.level)
 
 function map_cell_to_geo_cube(xout, xin, cell_ids_mat)

--- a/src/cubes.jl
+++ b/src/cubes.jl
@@ -109,7 +109,7 @@ function to_geo_cube(cell_cube::CellCube; longitudes=-180:180, latitudes=-90:90)
 end
 
 
-function to_geo_cube(cell_cube::CellCube, cell_ids::DimArray{Q2DI,2})
+function to_geo_cube(cell_cube::CellCube, cell_ids::DimArray{Q2DI{T},2}) where {T<:Integer}
     geo_array = mapCube(
         map_cell_to_geo_cube,
         cell_cube.data,
@@ -155,7 +155,7 @@ function plot_geo(cell_cube::CellCube; resolution::Real=800)
     plot_geo(cell_cube, cell_ids)
 end
 
-function plot_geo(cell_cube::CellCube, cell_ids::DimArray{Q2DI,2})
+function plot_geo(cell_cube::CellCube, cell_ids::DimArray{Q2DI{T},2}) where {T<:Integer}
     longitudes = dims(cell_ids, :X)
     latitudes = dims(cell_ids, :Y)
 

--- a/src/cubes.jl
+++ b/src/cubes.jl
@@ -43,7 +43,7 @@ function to_cell_cube(raster::AbstractDimArray, level::Integer, agg_func::Functi
     -90 <= minimum(lat_dim) <= maximum(lat_dim) <= 90 || error("$(name(lon_dim)) must be within [-90, 90]")
 
     @info "Step 1/2: Transform coordinates"
-    cell_ids_mat = transform_points(lon_dim, lat_dim, level)
+    cell_ids_mat = transform_points(lon_dim.val, lat_dim.val, level)
 
     # TODO: what if e.g. lon goes from 0 to 365?
     # TODO: Reverse inverted geo axes

--- a/src/dggrid.jl
+++ b/src/dggrid.jl
@@ -114,7 +114,7 @@ function transform_points(coords::Vector{Tuple{T,T}}, level; show_progress=true,
     return result
 end
 
-function transform_points(coords::Vector{Q2DI}, level; show_progress=true, chunk_size_points=2048) where {T<:Real}
+function transform_points(coords::Vector{Q2DI}, level; show_progress=true, chunk_size_points=2048)
     chunks = Iterators.partition(coords, chunk_size_points) |> collect
 
     if length(chunks) == 1
@@ -143,7 +143,7 @@ end
 """
 chunk_size_points: number of points (e.g. pixels) to transform in one block (task of a thread)
 """
-function transform_points(lon_range, lat_range, level; show_progress=true, chunk_size_points=2048)
+function transform_points(lon_range::AbstractVector{A}, lat_range::AbstractVector{B}, level::Integer; show_progress=true, chunk_size_points=2048) where {A<:Real,B<:Real}
     chunk_size_lon = chunk_size_points / length(lat_range) |> ceil |> Int
     lon_chunks = Iterators.partition(lon_range, chunk_size_lon) |> collect
 
@@ -169,5 +169,6 @@ function transform_points(lon_range, lat_range, level; show_progress=true, chunk
     end
 
     cell_ids_mat = hcat(cell_ids_mats...) |> permutedims
-    return cell_ids_mat
+    cell_ids = DimArray(cell_ids_mat, (lon_range |> X, lat_range |> Y))
+    return cell_ids
 end

--- a/src/dggrid.jl
+++ b/src/dggrid.jl
@@ -22,7 +22,7 @@ function call_dggrid(meta::Dict)
 end
 
 # single threaded version
-function _transform_points(coords::AbstractVector{Q2DI}, level)
+function _transform_points(coords::AbstractVector{Q2DI{T}}, level) where {T<:Integer}
     points_path = tempname()
     points_string = ""
     for c in coords
@@ -114,7 +114,7 @@ function transform_points(coords::Vector{Tuple{T,T}}, level; show_progress=true,
     return result
 end
 
-function transform_points(coords::Vector{Q2DI}, level; show_progress=true, chunk_size_points=2048)
+function transform_points(coords::Vector{Q2DI{T}}, level; show_progress=true, chunk_size_points=2048) where {T<:Integer}
     chunks = Iterators.partition(coords, chunk_size_points) |> collect
 
     if length(chunks) == 1

--- a/src/gridsystems.jl
+++ b/src/gridsystems.jl
@@ -30,12 +30,6 @@ function GridSystem(cell_cube::CellCube)
     return GridSystem(pyramid)
 end
 
-function GridSystem(data::AbstractArray{<:Number}, lon_range::AbstractRange{<:Real}, lat_range::AbstractRange{<:Real}, level::Integer)
-    raster = DimArray(data, (X(lon_range), Y(lat_range)))
-    cell_cube = to_cell_cube(raster, level)
-    GridSystem(cell_cube)
-end
-
 function GridSystem(data::AbstractArray{<:Number}, lon_range::DimensionalData.Dimension, lat_range::DimensionalData.Dimension, level::Integer)
     raster = DimArray(data, (lon_range, lat_range))
     cell_cube = to_cell_cube(raster, level)

--- a/src/gridsystems.jl
+++ b/src/gridsystems.jl
@@ -9,13 +9,13 @@ function aggregate_cell_cube(xout, xin; agg_func=filter_null(mean))
     end
 end
 
-function GridSystem(cell_cube::CellCube)
+function GridSystem(cell_cube::CellCube; agg_func=filter_null(mean))
     pyramid = Dict{Int,CellCube}()
     pyramid[cell_cube.level] = cell_cube
 
     for coarser_level in cell_cube.level-1:-1:2
         coarser_cell_array = mapCube(
-            aggregate_cell_cube,
+            (xout, xin) -> aggregate_cell_cube(xout, xin; agg_func=agg_func),
             pyramid[coarser_level+1].data,
             indims=InDims(:q2di_i, :q2di_j),
             outdims=OutDims(
@@ -30,9 +30,9 @@ function GridSystem(cell_cube::CellCube)
     return GridSystem(pyramid)
 end
 
-function GridSystem(data::AbstractArray{<:Number}, lon_range::DimensionalData.Dimension, lat_range::DimensionalData.Dimension, level::Integer)
+function GridSystem(data::AbstractArray{<:Number}, lon_range::DimensionalData.Dimension, lat_range::DimensionalData.Dimension, level::Integer; kwargs...)
     raster = DimArray(data, (lon_range, lat_range))
-    cell_cube = to_cell_cube(raster, level)
+    cell_cube = to_cell_cube(raster, level; kwargs...)
     GridSystem(cell_cube)
 end
 

--- a/src/gridsystems.jl
+++ b/src/gridsystems.jl
@@ -4,7 +4,8 @@ function aggregate_cell_cube(xout, xin; agg_func=filter_null(mean))
         for i in axes(xout, 1)
             iview = ((i-1)*fac+1):min(size(xin, 1), (i * fac))
             jview = ((j-1)*fac+1):min(size(xin, 2), (j * fac))
-            xout[i, j] = agg_func(view(xin, iview, jview))
+            data = view(xin, iview, jview)
+            xout[i, j] = agg_func(data)
         end
     end
 end
@@ -30,7 +31,13 @@ function GridSystem(cell_cube::CellCube; agg_func=filter_null(mean))
     return GridSystem(pyramid)
 end
 
-function GridSystem(data::AbstractArray{<:Number}, lon_range::DimensionalData.Dimension, lat_range::DimensionalData.Dimension, level::Integer; kwargs...)
+function GridSystem(data::AbstractArray{<:Number}, lon_range::AbstractVector, lat_range::AbstractVector, level::Integer; kwargs...)
+    raster = DimArray(data, (X(lon_range), Y(lat_range)))
+    cell_cube = to_cell_cube(raster, level; kwargs...)
+    GridSystem(cell_cube)
+end
+
+function GridSystem(data::AbstractArray{<:Number}, lon_range::DimensionalData.XDim, lat_range::DimensionalData.YDim, level::Integer; kwargs...)
     raster = DimArray(data, (lon_range, lat_range))
     cell_cube = to_cell_cube(raster, level; kwargs...)
     GridSystem(cell_cube)

--- a/src/types.jl
+++ b/src/types.jl
@@ -4,11 +4,13 @@ struct ColorScale{T<:Real}
     max_value::T
 end
 
-struct Q2DI
-    n
-    i
-    j
+struct Q2DI{T<:Integer}
+    n::UInt8
+    i::T
+    j::T
 end
+
+Q2DI(n::Integer, i::T, j::T) where {T<:Integer} = Q2DI(UInt8(n), T(i), T(j))
 
 struct CellCube
     data::YAXArray

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,6 +12,10 @@ end
 
 Q2DI(n::Integer, i::T, j::T) where {T<:Integer} = Q2DI(UInt8(n), T(i), T(j))
 
+function Base.show(io::IO, ::MIME"text/plain", i::Q2DI{T}) where {T<:Integer}
+    println(io, "Q2DI($(i.n), $(i.i), $(i.j))")
+end
+
 struct CellCube
     data::YAXArray
     level::Integer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,71 +4,68 @@ using YAXArrays
 using GLMakie
 using Test
 
-@testset verbose = true "DGGS.jl" begin
-    lon_range = X(-180:180)
-    lat_range = Y(-90:90)
-    level = 6
-    data = [exp(cosd(lon)) + 3(lat / 90) for lon in lon_range, lat in lat_range]
+lon_range = X(-180:180)
+lat_range = Y(-90:90)
+level = 6
+data = [exp(cosd(lon)) + 3(lat / 90) for lon in lon_range, lat in lat_range]
 
-    raster = DimArray(data, (lon_range, lat_range))
-    cell_cube = to_cell_cube(raster, level)
-    dggs = GridSystem(data, lon_range, lat_range, level)
-    dggs = GridSystem(data, -180:180, -90:90, level)
+raster = DimArray(data, (lon_range, lat_range))
+cell_cube = to_cell_cube(raster, level)
+dggs = GridSystem(data, lon_range, lat_range, level)
+dggs = GridSystem(data, -180:180, -90:90, level)
 
-    geo_arr = YAXArray((lon_range, lat_range), data)
-    cell_cube2 = to_cell_cube(geo_arr, 5)
-    dggs2 = GridSystem(cell_cube2)
+geo_arr = YAXArray((lon_range, lat_range), data)
+cell_cube2 = to_cell_cube(geo_arr, 5)
+dggs2 = GridSystem(cell_cube2)
 
-    @test typeof(cell_cube) == CellCube
-    @test typeof(dggs) == GridSystem
-    @test keys(dggs.data) |> maximum == 6
+@test typeof(cell_cube) == CellCube
+@test typeof(dggs) == GridSystem
+@test keys(dggs.data) |> maximum == 6
 
-    # convert back and forth
-    raster2 = raster |> x -> to_cell_cube(x, level) |> to_geo_cube
-    @test name.(dims(raster2)) == (:lon, :lat)
+# convert back and forth
+raster2 = raster |> x -> to_cell_cube(x, level) |> to_geo_cube
+@test name.(dims(raster2)) == (:lon, :lat)
 
-    dggs_path = tempname()
-    write(dggs_path, dggs)
-    dggs2 = GridSystem(dggs_path)
-    rm(dggs_path, recursive=true)
+dggs_path = tempname()
+write(dggs_path, dggs)
+dggs2 = GridSystem(dggs_path)
+rm(dggs_path, recursive=true)
 
 
-    time_range = 1:12
-    level = 6
-    bands = 1:3
-    data = [band * exp(cosd(lon)) + time * (lat / 90)
-            for lat in lat_range, lon in lon_range, time in time_range, band in bands]
-    axlist = (
-        lat_range,
-        lon_range,
-        Dim{:time}(time_range),
-        Dim{:band}(bands)
-    )
-    dggs2 = YAXArray(axlist, data) |> x -> to_cell_cube(x, level) |> GridSystem
-    @test dggs2 |> CellCube |> x -> x.data |> dims |> length == 5
-    @test dggs2[6][band=1, time=2] |> typeof == CellCube
-    @test dggs2[6][band=2, time=2].data.axes |> length == 3
+time_range = 1:12
+level = 6
+bands = 1:3
+data = [band * exp(cosd(lon)) + time * (lat / 90)
+        for lat in lat_range, lon in lon_range, time in time_range, band in bands]
+axlist = (
+    lat_range,
+    lon_range,
+    Dim{:time}(time_range),
+    Dim{:band}(bands)
+)
+dggs2 = YAXArray(axlist, data) |> x -> to_cell_cube(x, level) |> GridSystem
+@test dggs2 |> CellCube |> x -> x.data |> dims |> length == 5
+@test dggs2[6][band=1, time=2] |> typeof == CellCube
+@test dggs2[6][band=2, time=2].data.axes |> length == 3
 
-    @test transform_points(-180:180, -90:90, 7) |> size == (361, 181)
-    @test transform_points(-180, -90, 7) |> size == (1, 1)
-    @test transform_points([(-180, -90), (0, 0), (180, 90)], 7) |> length == 3
-    @test transform_points([Q2DI(1, 1, 1), Q2DI(2, 2, 2)], 7) |> length == 2
+@test transform_points(-180:180, -90:90, 7) |> size == (361, 181)
+@test transform_points([(-180, -90), (0, 0), (180, 90)], 7) |> length == 3
+@test transform_points([Q2DI(1, 1, 1), Q2DI(2, 2, 2)], 7) |> length == 2
 
-    # converting back and forth must be approx the same at higher levels
-    geo_coords = [(lon, lat) for lon in -175:5:175, lat in -85:5:85] |> vec
-    level = 12
-    fwd_rev_geo_goords = geo_coords |> x -> transform_points(x, level) |> x -> transform_points(x, level)
-    @test geo_coords == map(x -> (round(x[1]), round(x[2])), fwd_rev_geo_goords)
+# converting back and forth must be approx the same at higher levels
+geo_coords = [(lon, lat) for lon in -175:5:175, lat in -85:5:85] |> vec
+level = 12
+fwd_rev_geo_goords = geo_coords |> x -> transform_points(x, level) |> x -> transform_points(x, level)
+@test geo_coords == map(x -> (round(x[1]), round(x[2])), fwd_rev_geo_goords)
 
-    plot(cell_cube)
-    plot(cell_cube; resolution=100)
-    plot(dggs; resolution=100)
-    plot(dggs2; resolution=100)
-    alaska = BBox(-180, -150, 50, 80)
-    plot(cell_cube, alaska; resolution=100)
-    plot(dggs, alaska; resolution=100)
-    plot(dggs2, alaska; resolution=100)
+@test plot(cell_cube) |> typeof == Figure
+@test plot(cell_cube; resolution=100) |> typeof == Figure
+@test plot(dggs; resolution=100) |> typeof == Figure
+@test plot(dggs2; resolution=100) |> typeof == Figure
+alaska = BBox(-180, -150, 50, 80)
+@test plot(cell_cube, alaska; resolution=100) |> typeof == Figure
+@test plot(dggs, alaska; resolution=100) |> typeof == Figure
+@test plot(dggs2, alaska; resolution=100) |> typeof == Figure
 
-    dggs3 = GridSystem("https://s3.bgc-jena.mpg.de:9000/dggs/modis")
-    @test typeof(dggs3) == GridSystem
-end
+dggs3 = GridSystem("https://s3.bgc-jena.mpg.de:9000/dggs/modis")
+@test typeof(dggs3) == GridSystem


### PR DESCRIPTION
Currently, a `CellCube` uses function `Cube` to create the array in which all variables are squeezed into just one dimension. Disentangling these variables, i.e. using `Dataset` instead of `YAXArray` for a `CellCube` has the following advantages:

- Allows chunking for separate vars
- Allows loading of vars individually
- Allows individual metadata for each variable