### PR TITLE
Flatten DGGS attrs

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -20,9 +20,9 @@ function DGGSArray(arr::AbstractArray, level::Integer, id=:layer)
         Dim{:q2di_n}(0:11),
     )
 
-    props = DGGS.Q2DI_DGGS_PROPS
-    props["name"] => id
-    props["dggs_level"] => level
+    props = deepcopy(DGGS.Q2DI_DGGS_PROPS)
+    props["name"] = id
+    props["dggs_level"] = level
 
     data = YAXArray(axs, arr, props)
     DGGSArray(data)

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,9 +1,9 @@
 function DGGSArray(arr::YAXArray, id::Symbol)
-    haskey(arr.properties, "_DGGS") || error("Array is not in DGGS format")
+    haskey(arr.properties, "dggs_id") || error("Array is not in DGGS format")
 
     attrs = arr.properties
-    level = attrs["_DGGS"]["level"]
-    dggs = DGGSGridSystem(attrs["_DGGS"])
+    level = attrs["dggs_level"]
+    dggs = DGGSGridSystem(attrs)
 
     DGGSArray(arr, attrs, id, level, dggs)
 end
@@ -19,11 +19,11 @@ function DGGSArray(arr::AbstractArray, level::Integer, id=:layer)
         Dim{:q2di_j}(range(0; step=1, length=2^(level - 1))),
         Dim{:q2di_n}(0:11),
     )
-    props = Dict{String,Any}(
-        "name" => id,
-        "_DGGS" => DGGS.Q2DI_DGGS_PROPS
-    )
-    props["_DGGS"]["level"] = level
+
+    props = DGGS.Q2DI_DGGS_PROPS
+    props["name"] => id
+    props["dggs_level"] => level
+
     data = YAXArray(axs, arr, props)
     DGGSArray(data)
 end
@@ -241,8 +241,8 @@ function to_dggs_array(
     end
 
     props = raster |> metadata |> typeof == Dict{String,Any} ? deepcopy(metadata(raster)) : Dict{String,Any}()
-    props["_DGGS"] = deepcopy(Q2DI_DGGS_PROPS)
-    props["_DGGS"]["level"] = level
+    props = Dict(union(props, Q2DI_DGGS_PROPS))
+    props["dggs_level"] = level
     cell_array = YAXArray(cell_array.axes, cell_array.data, props)
     DGGSArray(cell_array, id)
 end
@@ -658,8 +658,7 @@ import Base: broadcasted, +, -, *, /, \
 function Base.broadcasted(f::Function, a::DGGSArray, number::Real)
     data = f.(a.data, number)
 
-    # meta data may be invalidated after transformation
-    properties = Dict("_DGGS" => deepcopy(data.properties["_DGGS"]))
+    properties = deepcopy(data.properties)
     array = YAXArray(data.axes, data.data, properties)
 
     res = DGGSArray(array)

--- a/src/layer.jl
+++ b/src/layer.jl
@@ -1,6 +1,6 @@
 
 function DGGSLayer(data::YAXArrays.Dataset)
-    haskey(data.properties, "_DGGS") || error("Dataset is not in DGGS format")
+    haskey(data.properties, "dggs_id") || error("Dataset is not in DGGS format")
 
     layer = Dict{Symbol,DGGSArray}()
     for (k, c) in data.cubes

--- a/src/layer.jl
+++ b/src/layer.jl
@@ -123,7 +123,11 @@ function to_dggs_layer(
         verbose && @info "Tranform band $band"
         data[band] = to_dggs_array(geo_arr, level; cell_ids=cell_ids, verbose=false, lon_name=lon_name, lat_name=lat_name, kwargs...)
     end
-    DGGSLayer(data, level, geo_ds.properties, DGGSGridSystem(Q2DI_DGGS_PROPS))
+    properties = geo_ds.properties
+    properties = union(properties, Q2DI_DGGS_PROPS) |> Dict
+    properties["dggs_level"] = level
+
+    DGGSLayer(data, level, properties, DGGSGridSystem(Q2DI_DGGS_PROPS))
 end
 
 to_dggs_layer(raster::AbstractDimArray, level::Integer, args...; kwargs...) = to_dggs_array(raster, level; kwargs...) |> DGGSLayer

--- a/src/pyramid.jl
+++ b/src/pyramid.jl
@@ -82,7 +82,7 @@ function write_dggs_pyramid(base_path::String, dggs::DGGSPyramid)
     end
 
     global_attrs = dggs.attrs
-    global_attrs["dggs_levels"] = levels
+    global_attrs["dggs_levels"] = dggs.levels
 
     JSON3.write("$base_path/.zattrs", global_attrs)
     JSON3.write("$base_path/.zgroup", Dict(:zarr_format => 2))

--- a/src/pyramid.jl
+++ b/src/pyramid.jl
@@ -42,10 +42,10 @@ end
 
 function open_dggs_pyramid(path::String)
     root_group = zopen(path)
-    haskey(root_group.attrs, "_DGGS") || error("Zarr store is not in DGGS format")
+    haskey(root_group.attrs, "dggs_id") || error("Zarr store is not in DGGS format")
 
     pyramid = Dict{Int,DGGSLayer}()
-    for level in sort(root_group.attrs["_DGGS"]["levels"])
+    for level in sort(root_group.attrs["dggs_levels"])
         layer_ds = open_dataset(root_group.groups["$level"])
         pyramid[level] = DGGSLayer(layer_ds)
     end
@@ -64,10 +64,7 @@ function write_dggs_pyramid(base_path::String, dggs::DGGSPyramid)
         arrs = map((k, v) -> k => v.data, keys(dggs[level].data), values(dggs[level].data))
 
         attrs = dggs[level].attrs
-        attrs["_DGGS"] = Dict{Symbol,Any}(
-            key => getfield(dggs.dggs, key) for key in propertynames(dggs.dggs)
-        )
-        attrs["_DGGS"][:level] = level
+        attrs["dggs_level"] = level
 
         ds = Dataset(; properties=attrs, arrs...)
         savedataset(ds; path=level_path)
@@ -78,18 +75,14 @@ function write_dggs_pyramid(base_path::String, dggs::DGGSPyramid)
         for band in keys(ds.cubes)
             attrs = JSON3.read("$level_path/$band/.zattrs", Dict{String,Any})
             attrs = merge(attrs, dggs[level][band].attrs)
-            attrs["_DGGS"] = Dict{String,Any}(
-                String(key) => getfield(dggs.dggs, key) for key in propertynames(dggs.dggs)
-            )
-            attrs["_DGGS"]["level"] = level
+            attrs["dggs_level"] = level
             JSON3.write("$level_path/$band/.zattrs", attrs)
             Zarr.consolidate_metadata("$level_path/$band")
         end
     end
 
     global_attrs = dggs.attrs
-    global_attrs["_DGGS"] = Dict{String,Any}(String(key) => getfield(dggs.dggs, key) for key in propertynames(dggs.dggs))
-    global_attrs["_DGGS"]["levels"] = dggs.levels
+    global_attrs["dggs_levels"] = levels
 
     JSON3.write("$base_path/.zattrs", global_attrs)
     JSON3.write("$base_path/.zgroup", Dict(:zarr_format => 2))
@@ -249,7 +242,7 @@ function to_dggs_pyramid(l::DGGSLayer; base_path=tempname())
                 )
             )
             attrs = deepcopy(arr.attrs)
-            attrs["_DGGS"]["level"] = coarser_level
+            attrs["dggs_level"] = coarser_level
             coarser_arr = YAXArray(coarser_arr.axes, coarser_arr.data, attrs)
             coarser_data[k] = DGGSArray(coarser_arr, attrs, k, coarser_level, finer_layer.dggs)
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -21,7 +21,7 @@ struct DGGSGridSystem
     projection::String
 end
 
-DGGSGridSystem(d::Dict{String,Any}) = DGGSGridSystem(d["id"], d["index"], d["polygon"], d["aperture"], d["projection"])
+DGGSGridSystem(d::Dict{String,Any}) = DGGSGridSystem(d["dggs_id"], d["dggs_index"], d["dggs_polygon"], d["dggs_aperture"], d["dggs_projection"])
 
 Base.show(io::IO, ::MIME"text/plain", dggs::DGGSGridSystem) = Base.show_default(io, dggs)
 
@@ -96,14 +96,14 @@ end
 
 
 const Q2DI_DGGS_PROPS = Dict(
-    "index" => "Q2DI",
-    "aperture" => 4,
-    "rotation_lon" => 11.25,
-    "polyhedron" => "icosahedron",
-    "id" => "DGGRID ISEA4H Q2DI",
-    "radius" => 6371007.180918475,
-    "polygon" => "hexagon",
-    "rotation_lat" => 58.2825,
-    "projection" => "isea",
-    "rotation_azimuth" => 0
+    "dggs_index" => "Q2DI",
+    "dggs_projection" => "isea",
+    "dggs_id" => "DGGRID ISEA4H Q2DI",
+    "dggs_polyhedron" => "icosahedron",
+    "dggs_polygon" => "hexagon",
+    "dggs_aperture" => 4,
+    "dggs_radius" => 6371007.180918475,
+    "dggs_rotation_lon" => 11.25,
+    "dggs_rotation_lat" => 58.2825,
+    "dggs_rotation_azimuth" => 0
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ a = l.tas
 @test a.id == :tas
 @test length(p.attrs) == length(l.attrs)
 @test length(a.attrs) > length(p.attrs)
-@test (setdiff(p.attrs, l.attrs) .|> x -> x.first) == ["_DGGS"] # same global attrs expect DGGS level
+@test (setdiff(p.attrs, l.attrs) .|> x -> x.first) == ["dggs_level"] # same global attrs expect DGGS level
 
 @test a[10, 1, 1] isa YAXArray
 @test (a[10, 1, 1] .== a[Q2DI(10, 1, 1)]) |> collect |> all
@@ -92,8 +92,8 @@ data = zeros(4, 4, 12)
 data[:, :, 2] = [0 0 0 0; 0 0 0 0; 0 0 1 1; 0 0 1 1]
 level = 3
 axs = (Dim{:q2di_i}(1:4), Dim{:q2di_j}(1:4), Dim{:q2di_n}(1:12))
-props = Dict("_DGGS" => deepcopy(DGGS.Q2DI_DGGS_PROPS))
-props["_DGGS"]["level"] = level
+props = deepcopy(DGGS.Q2DI_DGGS_PROPS)
+props["dggs_level"] = level
 a = YAXArray(axs, data, props) |> DGGSArray
 p = to_dggs_pyramid(a)
 expected = [0 0; 0 0.625]


### PR DESCRIPTION
Zarr and HDF5 support nested variable attributes but NetCDF and CF conventions don't.
This PR flattens DGGS attributes to ensure compatibility with NetCDF and CF.