### PR TITLE
Fix outtype round

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -243,7 +243,7 @@ function to_dggs_array(
             Dim{:q2di_j}(range(0; step=1, length=2^(level - 1))),
             Dim{:q2di_n}(0:11),
             outtype=Dict(
-                :round => Bool,
+                :round => any(Base.uniontypes(eltype(raster)) .<: Integer) ? filter(x -> x != Missing, Base.uniontypes(eltype(raster)))[1] : Bool,
                 :convert => Float64,
                 :identity => filter(x -> x != Missing, Base.uniontypes(eltype(raster)))[1]
             )[agg_type],

--- a/src/layer.jl
+++ b/src/layer.jl
@@ -18,7 +18,7 @@ end
 
 function DGGSLayer(arr::DGGSArray)
     data = Dict{Symbol,DGGSArray}()
-    data[:layer] = arr
+    data[arr.id] = arr
     DGGSLayer(data, arr.level, arr.attrs, arr.dggs)
 end
 

--- a/src/pyramid.jl
+++ b/src/pyramid.jl
@@ -119,7 +119,7 @@ function aggregate_pentagon!(xout::AbstractArray, xin::AbstractArray, n::Integer
         idx[1] = i
         idx[2] = j
         idx[3] = n
-        xin.parent[idx...]
+        a.data[idx...]
     end
     res = filter_null(mean)(vals) |> Dict(:round => round, :convert => identity, :identity => identity)[agg_type]
     xout[1, 1] = res
@@ -178,8 +178,8 @@ function aggregate_hexagons!(xout::AbstractArray, xin::AbstractArray, n::Integer
     row_idx[2] = row_paddings[n][2]
     row_idx[3] = row_paddings[n][3]
 
-    padded_xin = hcat(xin.parent[col_idx...], xin)
-    padded_xin = vcat(vcat([missing], xin.parent[row_idx...])', padded_xin)
+    padded_xin = hcat(a.data[col_idx...], xin)
+    padded_xin = vcat(vcat([missing], a.data[row_idx...])', padded_xin)
 
     kernel = Float64[1 1 0; 1 2 1; 0 1 1] |> x -> x ./ sum(x)
     kernel_stride = 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,7 +58,7 @@ geo_ds = Dataset(; properties=geo_ds.properties, arrs...)
 dggs2 = to_dggs_pyramid(geo_ds, level)
 l2 = dggs2[2]
 @test l2.area.data |> eltype == Union{Missing,Float32}
-@test l2.msk_rgn.data |> eltype == Union{Missing,Bool}
+@test l2.msk_rgn.data |> eltype == Union{Missing,Int32}
 @test maximum(dggs2.levels) == level
 @test minimum(dggs2.levels) == 2
 @test dggs2.attrs == dggs2[2].attrs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,9 +17,8 @@ l = p[4]
 a = l.tas
 
 @test a.id == :tas
-@test length(p.attrs) == length(l.attrs)
 @test length(a.attrs) > length(p.attrs)
-@test (setdiff(p.attrs, l.attrs) .|> x -> x.first) == ["dggs_level"] # same global attrs expect DGGS level
+@test (setdiff(p.attrs, l.attrs) .|> x -> x.first) == ["dggs_levels", "dggs_level"] # same global attrs expect DGGS level
 
 @test a[10, 1, 1] isa YAXArray
 @test (a[10, 1, 1] .== a[Q2DI(10, 1, 1)]) |> collect |> all


### PR DESCRIPTION
Element outtype was always Bool if agg_type was set to :round. This PR fixes it by setting the element outtype to the original eleemt type.