### PR TITLE
Fix dimtree for DGGSDataset

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -98,21 +98,18 @@ end
 function get_geo_bbox(geo_array::AbstractDimArray, crs::String)
     # use default thread pool for lat/lon conversion
     wgs84_crs_geogcs = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]"
+
+    x_min, x_max = extrema(geo_array.X)
+    y_min, y_max = extrema(geo_array.Y)
+
     if crs in [wgs84_crs_geogcs, "EPSG:4326"]
-        lon_min, lon_max = geo_array.X[1], geo_array.X[end]
-        lat_min, lat_max = geo_array.Y[1], geo_array.Y[end]
-        # axis might be reversed
-        lon_min, lon_max = minmax(lon_min, lon_max)
-        lat_min, lat_max = minmax(lat_min, lat_max)
-        ext = Extent(X=(lon_min, lon_max), Y=(lat_min, lat_max))
+        ext = Extent(X=(x_min, x_max), Y=(y_min, y_max))
         return ext
     else
         trans = Proj.Transformation(crs, crs_geo)
-        lat_min, lon_min = trans(geo_array.X[1], geo_array.Y[1])
-        lat_max, lon_max = trans(geo_array.X[end], geo_array.Y[end])
-        # axis might be reversed
-        lon_min, lon_max = minmax(lon_min, lon_max)
-        lat_min, lat_max = minmax(lat_min, lat_max)
+        lat_min, lon_min = trans(x_min, y_min)
+        lat_max, lon_max = trans(x_max, y_max)
+
         ext = Extent(X=(lon_min, lon_max), Y=(lat_min, lat_max))
         return ext
     end

--- a/src/datasets.jl
+++ b/src/datasets.jl
@@ -33,6 +33,16 @@ function DGGSDataset(dggs_arrays...; kwargs...)
     )
 end
 
+# # serialise to dimtree node
+# function DimTree(dggs_ds::DGGSDataset)
+#     attrs = Dict{String,Any}()
+#     attrs["dggs_dggsrs"] = dggs_ds.dggsrs
+#     attrs["dggs_resolution"] = dggs_ds.resolution
+#     ds = DimStack(dggs_ds; metadata=Dict(:foo => 2))
+#     dimtree = DimTree(ds; metadata=Dict(:foo => 2))
+#     return dimtree
+# end
+
 Base.propertynames(ds::DGGSDataset) = union((:resolution, :dggsrs), Base.propertynames(parent(ds)))
 
 function Base.getproperty(ds::DGGSDataset, s::Symbol)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -175,6 +175,10 @@ dggs_ds = DGGSDataset(dggs_array, dggs_array2)
         @test dggs_p.dggsrs == dggs_p2.dggsrs
         @test length(dggs_p.data) == length(dggs_p2.data)
         @test all(keys(dggs_p.data) .== keys(dggs_p2.data))
+
+        # both layers must be present after save and open
+        @test name(dggs_p.dggs_s3.air_temperature) == name(dggs_p2.dggs_s3.air_temperature)
+        @test name(dggs_p.dggs_s3.precipitation) == name(dggs_p2.dggs_s3.precipitation)
         rm(temp_dir, recursive=true)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,12 @@ geo_data = [exp(cosd(lon)) + 3(lat / 90) for lon in lon_range, lat in lat_range]
 properties = Dict("standard_name" => "air_temperature", "units" => "K", "description" => "random test data")
 geo_array = YAXArray((lon_range, lat_range), geo_data, properties)
 dggs_array = to_dggs_array(geo_array, resolution, "EPSG:4326")
-dggs_ds = DGGSDataset(dggs_array)
+
+properties2 = Dict("standard_name" => "precipitation")
+geo_array2 = YAXArray((lon_range, lat_range), geo_data, properties2)
+dggs_array2 = to_dggs_array(geo_array2, resolution, "EPSG:4326")
+
+dggs_ds = DGGSDataset(dggs_array, dggs_array2)
 
 @testset "DGGS.jl" begin
     @testset "Cells" begin
@@ -154,6 +159,8 @@ dggs_ds = DGGSDataset(dggs_array)
     @testset "DGGSPyramid" begin
         dggs_p = to_dggs_pyramid(dggs_ds)
         @test dggs_p isa DGGSPyramid
+        @test dggs_p.dggs_s3 isa DGGSDataset
+        @test dggs_p.dggs_s3.air_temperature isa DGGSArray
         @test length(dggs_p.branches) == dggs_ds.resolution
         @test dggs_p.dggsrs == dggs_ds.dggsrs
         @test dggs_p.bbox == dggs_ds.bbox


### PR DESCRIPTION
A DGGSPyramid is a subtype of an AbstrctDimTree. However, the leaves are DimTrees as well. This PR fixes the getproperty of a pyramid to return a DGGSDataset with all layers at a given resolution instead of a DimTree object or truncated array.