### PR TITLE
Add subset array support

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -188,5 +188,9 @@ dggs_ds = DGGSDataset(dggs_array, dggs_array2)
         dggs_p2 = to_dggs_pyramid(dggs_array)
         @test all([dggs_p2[x] isa DGGSDataset for x in 1:3])
         @test all([dggs_p2[x].air_temperature isa DGGSArray for x in 1:3])
+
+        # pyramid from a subset
+        geo_array4 = geo_array[X=20:30, Y=17:22]
+        p = to_dggs_pyramid(geo_array4, resolution, "EPSG:4326")
     end
 end


### PR DESCRIPTION
- prevents to allocate more memory than needed, e.g. during pyramid building of a single high res S2 tile
- sorts resolution branches by name