### PR TITLE
Add direct write

### DIFF
--- a/src/pyramids.jl
+++ b/src/pyramids.jl
@@ -77,7 +77,8 @@ end
 
 function coarsen(
     dggs_array::DGGSArray;
-    pyramid_agg_func::Function=x -> filter(y -> !ismissing(y) && !isnan(y), x) |> mean
+    pyramid_agg_func::Function=x -> filter(y -> !ismissing(y) && !isnan(y), x) |> mean,
+    kwargs...
 )
     coarser_level = dggs_array.resolution - 1
 
@@ -92,7 +93,7 @@ function coarsen(
     coarser_arr = mapCube(
         dggs_array;
         indims=InDims(:dggs_i, :dggs_j),
-        outdims=OutDims(coarser_dims...)
+        outdims=OutDims(coarser_dims...; kwargs...)
     ) do xout, xin
         xout = aggregate_by_factor(xin, xout, pyramid_agg_func)
     end
@@ -152,10 +153,12 @@ function to_dggs_pyramid(
     resolution::Integer,
     crs::String;
     pyramid_agg_func::Function=x -> filter(y -> !ismissing(y) && !isnan(y), x) |> mean,
+    outtype_sums,
+    outtype,
     kwargs...
 )
-    dggs_ds = to_dggs_dataset(geo_ds, resolution, crs; kwargs...)
-    dggs_pyramid = to_dggs_pyramid(dggs_ds; pyramid_agg_func=pyramid_agg_func)
+    dggs_ds = to_dggs_dataset(geo_ds, resolution, crs; outtype=outtype, outtype_sums=outtype_sums, kwargs...)
+    dggs_pyramid = to_dggs_pyramid(dggs_ds; pyramid_agg_func=pyramid_agg_func, kwargs...)
     return dggs_pyramid
 end
 
@@ -167,7 +170,7 @@ function to_dggs_pyramid(
     kwargs...
 )
     dggs_array = to_dggs_array(geo_array, resolution, crs; kwargs...)
-    dggs_pyramid = to_dggs_pyramid(dggs_array; pyramid_agg_func=pyramid_agg_func)
+    dggs_pyramid = to_dggs_pyramid(dggs_array; pyramid_agg_func=pyramid_agg_func, kwargs...)
     return dggs_pyramid
 end
 


### PR DESCRIPTION
This PR aims to allow for concurrent writing of arrays during dgggs array and pyramid building.
No need to save_dggs_pyramid afterwards anymore.
By default, each array can be saved in a different file path if one sets backend arg other than array.

### Distributed writes
see https://docs.xarray.dev/en/stable/user-guide/io.html#distributed-writes and https://juliadatacubes.github.io/YAXArrays.jl/dev/UserGuide/write.html#Save-Skeleton.
After loading Zarr, one can set a base_path to save arrays in the same store.
