### PR TITLE
Add TileArray close #183 close #182

### DIFF
--- a/src/DGGS.jl
+++ b/src/DGGS.jl
@@ -26,7 +26,7 @@ const transformations = Channel{Proj.Transformation}(Inf)
 const inv_transformations = Channel{Proj.Transformation}(Inf)
 const threads_ready = Ref(false)
 
-export Cell, DGGSArray, DGGSDatase, Cell, DGGSArray, DGGSDataset, DGGSPyramid
+export Cell, ChunkedArray, DGGSArray, DGGSDataset, DGGSPyramid
 export to_cell, to_geo, to_dggs_pyramid, to_dggs_dataset, to_dggs_array, to_geo_dataset, to_geo_array
 export open_dggs_array, open_dggs_dataset, open_dggs_pyramid
 export save_dggs_array, save_dggs_dataset, save_dggs_pyramid

--- a/src/DGGS.jl
+++ b/src/DGGS.jl
@@ -17,6 +17,7 @@ using DiskArrayTools
 
 include("types.jl")
 include("cells.jl")
+include("chunked-array.jl")
 include("arrays.jl")
 include("datasets.jl")
 include("pyramids.jl")

--- a/src/DGGS.jl
+++ b/src/DGGS.jl
@@ -17,7 +17,7 @@ using DiskArrayTools
 
 include("types.jl")
 include("cells.jl")
-include("chunked-array.jl")
+include("tile-array.jl")
 include("arrays.jl")
 include("datasets.jl")
 include("pyramids.jl")
@@ -26,7 +26,7 @@ const transformations = Channel{Proj.Transformation}(Inf)
 const inv_transformations = Channel{Proj.Transformation}(Inf)
 const threads_ready = Ref(false)
 
-export Cell, ChunkedArray, DGGSArray, DGGSDataset, DGGSPyramid
+export Cell, TileArray, DGGSArray, DGGSDataset, DGGSPyramid
 export to_cell, to_geo, to_dggs_pyramid, to_dggs_dataset, to_dggs_array, to_geo_dataset, to_geo_array
 export open_dggs_array, open_dggs_dataset, open_dggs_pyramid
 export save_dggs_array, save_dggs_dataset, save_dggs_pyramid

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -339,6 +339,15 @@ function DGGSArray(array::AbstractDimArray)
     )
 end
 
+function DGGSArray(resolution; chunk_length=2^12)
+    spatial_dims = (Dim{:dggs_i}(0:2*2^resolution-1), Dim{:dggs_j}(0:2^resolution-1), Dim{:dggs_n}(0:4))
+    data = TileArray{Union{Missing,Float64}}(missing, length.(spatial_dims), (chunk_length, chunk_length, 1))
+    dggsrs = "ISEA4D.Penta"
+    bbox = Extent(X=(-180, 180), Y=(-90, 90))
+    a = DGGSArray(data, spatial_dims, (), DimensionalData.NoName(), DimensionalData.Dimensions.Lookups.NoMetadata(), resolution, dggsrs, bbox)
+    return a
+end
+
 function YAXArrays.YAXArray(dggs_array::DGGSArray)
     properties = Dict{String,Any}(metadata(dggs_array))
     properties["dggs_resolution"] = dggs_array.resolution
@@ -377,6 +386,7 @@ Base.getindex(a::DGGSArray, c::Cell) = YAXArray(a)[dggs_i=At(c.i), dggs_j=At(c.j
 
 # DGGSArrays are usually big. Like YAXArrays, avoid DiskArray to load everything in memory
 Base.getindex(a::DGGSArray; i...) = view(a; i...)
+
 
 #
 # IO:: Serialization of DGGS Arrays

--- a/src/chunked-array.jl
+++ b/src/chunked-array.jl
@@ -64,6 +64,8 @@ function Base.iterate(A::ChunkedArray, state=1)
     return (getindex(A, I...), state + 1)
 end
 
-# function Base.skipmissing(a::ChunkedArray)
-
-# end
+function Base.show(io::IO, ::MIME"text/plain", a::ChunkedArray)
+    print(io, join(a.dims, "x"))
+    print(io, " ")
+    print(io, typeof(a))
+end

--- a/src/chunked-array.jl
+++ b/src/chunked-array.jl
@@ -12,7 +12,7 @@ struct ChunkedArray{T,N} <: AbstractArray{T,N}
     chunk_size::NTuple{N,Int}
 end
 
-function ChunkedArray{T}(dims::NTuple{N,Int}, default::T, chunk_size::NTuple{N,Int}=dims) where {T,N}
+function ChunkedArray{T}(default::T, dims::NTuple{N,Int}, chunk_size::NTuple{N,Int}=dims) where {T,N}
     chunk_dims = ntuple(i -> div(dims[i] + chunk_size[i] - 1, chunk_size[i]), N)
     data = Array{Union{Missing,Array{T,N}},N}(undef, chunk_dims...)
     fill!(data, missing)

--- a/src/chunked-array.jl
+++ b/src/chunked-array.jl
@@ -1,0 +1,69 @@
+"""
+ChunkedArray operates just like any AbstractArray, but stores data in chunks. 
+This type is optimized for arrays that are dense in only some regions, but most chunks are just not expected to be filled.
+In this case, the default value is returned.
+This is the in-memory variant of Zarr DictStore, but without Compression and slow hash lookup of the Dict.
+Its ideal for global initialized DGGS arrays that only cover a small spatial region, e.g. a couple of UTM tiles.
+"""
+struct ChunkedArray{T,N} <: AbstractArray{T,N}
+    data::Array{Union{Missing,Array{T,N}},N}
+    default::T
+    dims::NTuple{N,Int}
+    chunk_size::NTuple{N,Int}
+end
+
+function ChunkedArray{T}(dims::NTuple{N,Int}, default::T, chunk_size::NTuple{N,Int}=dims) where {T,N}
+    chunk_dims = ntuple(i -> div(dims[i] + chunk_size[i] - 1, chunk_size[i]), N)
+    data = Array{Union{Missing,Array{T,N}},N}(undef, chunk_dims...)
+    fill!(data, missing)
+    ChunkedArray(data, default, dims, chunk_size)
+end
+
+function Base.size(A::ChunkedArray)
+    A.dims
+end
+
+function Base.length(A::ChunkedArray)
+    prod(A.dims)
+end
+
+function Base.eltype(A::ChunkedArray)
+    typeof(A.default)
+end
+
+Base.IndexStyle(::Type{<:ChunkedArray}) = IndexCartesian()
+
+function Base.getindex(A::ChunkedArray, I::Vararg{Int,N}) where {N}
+    if length(I) != length(A.dims)
+        throw(DimensionMismatch("Number of indices does not match array dimensions"))
+    end
+    chunk_key = ntuple(i -> div(I[i] - 1, A.chunk_size[i]) + 1, N)
+    chunk = A.data[chunk_key...]
+    if chunk === missing
+        return A.default
+    else
+        local_indices = ntuple(i -> mod(I[i] - 1, A.chunk_size[i]) + 1, N)
+        return chunk[local_indices...]
+    end
+end
+
+function Base.setindex!(A::ChunkedArray, value, I::Vararg{Int,N}) where {N}
+    chunk_key = ntuple(i -> div(I[i] - 1, A.chunk_size[i]) + 1, N)
+    if A.data[chunk_key...] === missing
+        A.data[chunk_key...] = fill(A.default, A.chunk_size...)
+    end
+    local_indices = ntuple(i -> mod(I[i] - 1, A.chunk_size[i]) + 1, N)
+    A.data[chunk_key...][local_indices...] = value
+end
+
+function Base.iterate(A::ChunkedArray, state=1)
+    if state > length(A)
+        return nothing
+    end
+    I = ntuple(i -> div(state - 1, prod(A.dims[i+1:end])) % A.dims[i] + 1, length(A.dims))
+    return (getindex(A, I...), state + 1)
+end
+
+# function Base.skipmissing(a::ChunkedArray)
+
+# end

--- a/src/tile-array.jl
+++ b/src/tile-array.jl
@@ -19,6 +19,14 @@ function TileArray{T}(default::T, dims::NTuple{N,Int}, chunk_size::NTuple{N,Int}
     TileArray(data, default, dims, chunk_size)
 end
 
+# infer eltype from default if not given
+function TileArray(default::T, dims::NTuple{N,Int}, chunk_size::NTuple{N,Int}=dims) where {T,N}
+    chunk_dims = ntuple(i -> div(dims[i] + chunk_size[i] - 1, chunk_size[i]), N)
+    data = Array{Union{Missing,Array{T,N}},N}(undef, chunk_dims...)
+    fill!(data, missing)
+    TileArray(data, default, dims, chunk_size)
+end
+
 function Base.size(A::TileArray)
     A.dims
 end

--- a/src/tile-array.jl
+++ b/src/tile-array.jl
@@ -5,35 +5,35 @@ In this case, the default value is returned.
 This is the in-memory variant of Zarr DictStore, but without Compression and slow hash lookup of the Dict.
 Its ideal for global initialized DGGS arrays that only cover a small spatial region, e.g. a couple of UTM tiles.
 """
-struct ChunkedArray{T,N} <: AbstractArray{T,N}
+struct TileArray{T,N} <: AbstractArray{T,N}
     data::Array{Union{Missing,Array{T,N}},N}
     default::T
     dims::NTuple{N,Int}
     chunk_size::NTuple{N,Int}
 end
 
-function ChunkedArray{T}(default::T, dims::NTuple{N,Int}, chunk_size::NTuple{N,Int}=dims) where {T,N}
+function TileArray{T}(default::T, dims::NTuple{N,Int}, chunk_size::NTuple{N,Int}=dims) where {T,N}
     chunk_dims = ntuple(i -> div(dims[i] + chunk_size[i] - 1, chunk_size[i]), N)
     data = Array{Union{Missing,Array{T,N}},N}(undef, chunk_dims...)
     fill!(data, missing)
-    ChunkedArray(data, default, dims, chunk_size)
+    TileArray(data, default, dims, chunk_size)
 end
 
-function Base.size(A::ChunkedArray)
+function Base.size(A::TileArray)
     A.dims
 end
 
-function Base.length(A::ChunkedArray)
+function Base.length(A::TileArray)
     prod(A.dims)
 end
 
-function Base.eltype(A::ChunkedArray)
+function Base.eltype(A::TileArray)
     typeof(A.default)
 end
 
-Base.IndexStyle(::Type{<:ChunkedArray}) = IndexCartesian()
+Base.IndexStyle(::Type{<:TileArray}) = IndexCartesian()
 
-function Base.getindex(A::ChunkedArray, I::Vararg{Int,N}) where {N}
+function Base.getindex(A::TileArray, I::Vararg{Int,N}) where {N}
     if length(I) != length(A.dims)
         throw(DimensionMismatch("Number of indices does not match array dimensions"))
     end
@@ -47,7 +47,7 @@ function Base.getindex(A::ChunkedArray, I::Vararg{Int,N}) where {N}
     end
 end
 
-function Base.setindex!(A::ChunkedArray, value, I::Vararg{Int,N}) where {N}
+function Base.setindex!(A::TileArray, value, I::Vararg{Int,N}) where {N}
     chunk_key = ntuple(i -> div(I[i] - 1, A.chunk_size[i]) + 1, N)
     if A.data[chunk_key...] === missing
         A.data[chunk_key...] = fill(A.default, A.chunk_size...)
@@ -56,7 +56,7 @@ function Base.setindex!(A::ChunkedArray, value, I::Vararg{Int,N}) where {N}
     A.data[chunk_key...][local_indices...] = value
 end
 
-function Base.iterate(A::ChunkedArray, state=1)
+function Base.iterate(A::TileArray, state=1)
     if state > length(A)
         return nothing
     end
@@ -64,7 +64,7 @@ function Base.iterate(A::ChunkedArray, state=1)
     return (getindex(A, I...), state + 1)
 end
 
-function Base.show(io::IO, ::MIME"text/plain", a::ChunkedArray)
+function Base.show(io::IO, ::MIME"text/plain", a::TileArray)
     print(io, join(a.dims, "x"))
     print(io, " ")
     print(io, typeof(a))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,29 @@ dggs_ds = DGGSDataset(dggs_array, dggs_array2)
         @test DGGSArray(yax_array, resolution, "ISEA4D.Penta", geo_bbox)[Cell(1, 2, 3, resolution)] isa YAXArray
     end
 
+    @testset "TileArray" begin
+        a = TileArray(0, (100, 100), (10, 10))
+        @test all(a .== 0)
+        a[1, 1] = 1
+        @test a[1, 1] == 1
+        @test all(a[2:100, :] .== 0)
+        a[1, 1] = 0
+        @test all(a .== 0)
+
+        a = TileArray{Union{Missing,Int}}(0, (100, 100), (10, 10))
+        a[1, 1] = 1
+        a[100, 100] = missing
+        @test a[1, 1] == 1
+        @test ismissing(a[100, 100])
+
+        resolution = 25
+        a = DGGSArray(resolution)
+        @test a.data isa TileArray
+        @test size(a) == (2 * 2^resolution, 2^resolution, 5)
+        a[2^resolution, 1, :] = 1:5
+        @test a.data[2^resolution, 1, :] == 1:5
+    end
+
     @testset "Coordinate transformations" begin
         resolution = 20
         geo_points = [(lon, lat) for lat in -90:5:90 for lon in -180:5:180]


### PR DESCRIPTION
This PR adds a new type TileArray which is a AbstractDimArray designed for raster data that covers only a continious fraction of the earths surface, allowing to hold data in memory that spans multiple quads.